### PR TITLE
Deprecate the CacheEncoderDecorator

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,14 @@
+# ChangeLog
+
+The changelog describes what is "Added", "Removed", "Changed" or "Fixed" between each release. 
+
+## v1.1.0
+
+### Deprecated
+
+* The `Rollerworks\Component\UriEncoder\Encoder\CacheEncoderDecorator`
+  is deprecated.
+  
+  The round trip of fetching cached encoded/decoded data is heavier then the
+  performance gained. And therefor caching the decoded results is no longer 
+  considered a good practice.

--- a/src/CacheAdapterInterface.php
+++ b/src/CacheAdapterInterface.php
@@ -11,8 +11,12 @@
 
 namespace Rollerworks\Component\UriEncoder;
 
+@trigger_error('The '.__NAMESPACE__.'\CacheAdapterInterface class is deprecated since version 1.1, to be removed in 2.0.', E_USER_DEPRECATED);
+
 /**
  * Interface for cache adapters.
+ *
+ * @deprecated since version 1.1, to be removed in 2.0.
  */
 interface CacheAdapterInterface
 {

--- a/src/Encoder/CacheEncoderDecorator.php
+++ b/src/Encoder/CacheEncoderDecorator.php
@@ -14,11 +14,15 @@ namespace Rollerworks\Component\UriEncoder\Encoder;
 use Rollerworks\Component\UriEncoder\CacheAdapterInterface;
 use Rollerworks\Component\UriEncoder\UriEncoderInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\CacheEncoderDecorator class is deprecated since version 1.1, to be removed in 2.0.', E_USER_DEPRECATED);
+
 /**
  * CacheEncoderDecorator keeps a cached version of original data
  * and delegates calls back to the original Encoder when no there is no cache.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * @deprecated since version 1.1, to be removed in 2.0.
  */
 class CacheEncoderDecorator implements UriEncoderInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

The round trip of fetching cached encoded/decoded data is heavier then the performance gained. And therefor caching the decoded results is no longer considered a good practice.
